### PR TITLE
feature (stocks): use thumbnail urls

### DIFF
--- a/frontend/app/stocks/page.tsx
+++ b/frontend/app/stocks/page.tsx
@@ -2,6 +2,7 @@
 "use client";
 import Link from "next/link";
 import useSWR from "swr";
+import { getThumbnailUrl } from "@/lib/getThumbnailUrl";
 
 type StockRow = {
   product_id: number;
@@ -51,7 +52,7 @@ export default function StockListPage() {
                 <td className="py-2 px-2">
                   {row.image_url ? (
                     <img
-                      src={row.image_url}
+                      src={getThumbnailUrl(row.image_url) || row.image_url}
                       alt={row.product_name}
                       className="w-12 h-12 object-cover rounded"
                       // 画像読み込みエラー時のフォールバック

--- a/frontend/components/ProductList.tsx
+++ b/frontend/components/ProductList.tsx
@@ -2,6 +2,7 @@
 import { apiGet } from "@/lib/api";
 import Image from "next/image";
 import Link from "next/link";
+import { getThumbnailUrl } from "@/lib/getThumbnailUrl";
 
 type Product = {
   id: number;
@@ -41,7 +42,11 @@ export default async function ProductList() {
               <td className="px-4 py-2 font-medium">
                 <div className="flex items-center gap-3">
                   <Image
-                    src={product.image_url || "/img/placeholder.svg"}
+                    src={
+                      getThumbnailUrl(product.image_url) ||
+                      product.image_url ||
+                      "/img/placeholder.svg"
+                    }
                     alt={product.name}
                     width={40}
                     height={40}

--- a/frontend/lib/getThumbnailUrl.ts
+++ b/frontend/lib/getThumbnailUrl.ts
@@ -1,0 +1,5 @@
+export function getThumbnailUrl(url: string | null): string | null {
+  if (!url) return null;
+  const match = url.match(/(.+)\/original\.[^./]+$/);
+  return match ? `${match[1]}/thumbnail.jpg` : null;
+}


### PR DESCRIPTION
## Why
Thumbnail images should be loaded instead of originals when available.

## What
- add `getThumbnailUrl` utility
- display thumbnails in stock list
- use thumbnails in product list

## How tested
- `npm --filter frontend build` *(fails: Unknown command `--filter`)*

------
https://chatgpt.com/codex/tasks/task_e_686cf2d48ea8832e847f5af23c47b581