### PR TITLE
feature(backend): add discord notifier

### DIFF
--- a/backend/src/models/discordConfig.js
+++ b/backend/src/models/discordConfig.js
@@ -1,0 +1,45 @@
+import { pool } from "../db.js";
+import crypto from "crypto";
+
+const algorithm = "aes-256-cbc";
+const key = (process.env.DISCORD_SECRET_KEY || "").padEnd(32, "0").slice(0, 32);
+
+function encrypt(text) {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(algorithm, key, iv);
+  const encrypted = Buffer.concat([cipher.update(text, "utf8"), cipher.final()]);
+  return `${iv.toString("hex")}:${encrypted.toString("hex")}`;
+}
+
+function decrypt(data) {
+  const [ivHex, enc] = data.split(":");
+  const iv = Buffer.from(ivHex, "hex");
+  const decipher = crypto.createDecipheriv(algorithm, key, iv);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(enc, "hex")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}
+
+export async function saveDiscordConfig(token, channelId) {
+  const encToken = encrypt(token);
+  const encChannel = encrypt(channelId);
+  await pool.query("DELETE FROM discord_config");
+  await pool.query(
+    "INSERT INTO discord_config (encrypted_token, encrypted_channel) VALUES ($1,$2)",
+    [encToken, encChannel]
+  );
+}
+
+export async function loadDiscordConfig() {
+  const { rows } = await pool.query(
+    "SELECT encrypted_token, encrypted_channel FROM discord_config LIMIT 1"
+  );
+  if (!rows.length) return null;
+  return {
+    token: decrypt(rows[0].encrypted_token),
+    channelId: decrypt(rows[0].encrypted_channel),
+  };
+}
+

--- a/backend/src/models/product.js
+++ b/backend/src/models/product.js
@@ -2,7 +2,7 @@ import { pool } from "../db.js";
 
 export const findByBarcode = async (barcode) => {
   const { rows } = await pool.query(
-    `SELECT id, barcode, name, brand, group_key, group_id, meta_json, created_at, updated_at,
+    `SELECT id, barcode, name, brand, group_key, group_id, notify, meta_json, created_at, updated_at,
             COALESCE(image_path, image_url) as image_url
      FROM products WHERE barcode=$1`,
     [barcode]
@@ -20,7 +20,7 @@ export const upsertProduct = async (barcode, p) => {
        VALUES($1, $2, $3, $4, $5, $6)
      ON CONFLICT(barcode) DO UPDATE
        SET name=EXCLUDED.name, image_url=EXCLUDED.image_url, meta_json=EXCLUDED.meta_json
-     RETURNING id, barcode, name, brand, group_key, group_id, meta_json, created_at, updated_at,
+     RETURNING id, barcode, name, brand, group_key, group_id, notify, meta_json, created_at, updated_at,
                COALESCE(image_path, image_url) as image_url`,
     [barcode, productName, p.brand, p.image, p.meta, p.group]
   );
@@ -28,7 +28,7 @@ export const upsertProduct = async (barcode, p) => {
 };
 export async function findById(id) {
   const res = await pool.query(
-    `SELECT id, barcode, name, brand, group_key, group_id, meta_json, created_at, updated_at,
+    `SELECT id, barcode, name, brand, group_key, group_id, notify, meta_json, created_at, updated_at,
             image_path, COALESCE(image_path, image_url) as image_url
      FROM products WHERE id = $1`,
     [id]
@@ -42,9 +42,17 @@ export async function findById(id) {
  */
 export async function listProducts() {
   const { rows } = await pool.query(
-    `SELECT id, barcode, name, brand, group_key, group_id, meta_json, created_at, updated_at,
+    `SELECT id, barcode, name, brand, group_key, group_id, notify, meta_json, created_at, updated_at,
             COALESCE(image_path, image_url) as image_url
      FROM products ORDER BY updated_at DESC`
   );
   return rows;
+}
+
+export async function updateNotify(id, notify) {
+  const { rows } = await pool.query(
+    `UPDATE products SET notify=$1 WHERE id=$2 RETURNING notify`,
+    [notify, id]
+  );
+  return rows[0] || null;
 }

--- a/backend/src/routes/__tests__/products.notify.test.js
+++ b/backend/src/routes/__tests__/products.notify.test.js
@@ -1,0 +1,22 @@
+import request from 'supertest';
+import express from 'express';
+import productsRouter from '../products.js';
+import { updateNotify } from '../../models/product.js';
+
+jest.mock('../../models/product.js', () => ({ updateNotify: jest.fn() }));
+
+const app = express();
+app.use(express.json());
+app.use('/api/products', productsRouter);
+
+describe('PATCH /api/products/:id/notify', () => {
+  test('updates notify flag', async () => {
+    updateNotify.mockResolvedValue({ notify: true });
+    const res = await request(app)
+      .patch('/api/products/1/notify')
+      .send({ notify: true });
+    expect(res.body).toEqual({ notify: true });
+    expect(updateNotify).toHaveBeenCalledWith(1, true);
+  });
+});
+

--- a/backend/src/routes/discord.js
+++ b/backend/src/routes/discord.js
@@ -1,0 +1,20 @@
+import express from "express";
+import { saveDiscordConfig } from "../models/discordConfig.js";
+
+const router = express.Router();
+
+router.post("/config", async (req, res, next) => {
+  try {
+    const { token, channelId } = req.body || {};
+    if (!token || !channelId) {
+      return res.status(400).json({ error: "invalid_config" });
+    }
+    await saveDiscordConfig(token, channelId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;
+

--- a/backend/src/routes/products.js
+++ b/backend/src/routes/products.js
@@ -8,6 +8,7 @@ import {
   findById,
   upsertProduct,
   listProducts,
+  updateNotify,
 } from "../models/product.js";
 import { uploadImageBufferToS3 } from "../lib/image-handler.js";
 import { createInitialStock } from "../models/stock.js";
@@ -167,6 +168,22 @@ router.put("/:id(\\d+)", async (req, res, next) => {
     }
 
     res.json(rows[0]);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// 通知設定を更新
+router.patch("/:id(\\d+)/notify", async (req, res, next) => {
+  try {
+    const id = Number(req.params.id);
+    const { notify } = req.body;
+    if (typeof notify !== "boolean") {
+      return res.status(400).json({ error: "invalid_notify" });
+    }
+    const updated = await updateNotify(id, notify);
+    if (!updated) return res.status(404).json({ error: "not_found" });
+    res.json(updated);
   } catch (err) {
     next(err);
   }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,8 @@ import stocks from "./routes/stocks.js";
 import shelves from "./routes/shelves.js";
 import groups from "./routes/groups.js";
 import meRouter from "./routes/me.js";
+import discordRouter from "./routes/discord.js";
+import { scheduleDailyNotifications } from "./services/discordNotifier.js";
 
 const app = express();
 app.use(cors({ origin: true, credentials: true }));
@@ -19,6 +21,9 @@ app.use("/api/stocks", stocks);
 app.use("/api/shelves", shelves);
 app.use("/api/groups", groups);
 app.use("/api/me", meRouter);
+app.use("/api/discord", discordRouter);
+
+scheduleDailyNotifications();
 
 app.get("/health", (_, res) => res.send("ok"));
 app.listen(3000, () => console.log("API listening on :3000"));

--- a/backend/src/services/__tests__/discordNotifier.test.js
+++ b/backend/src/services/__tests__/discordNotifier.test.js
@@ -1,0 +1,32 @@
+import { checkAndNotify } from '../discordNotifier.js';
+import { pool } from '../../db.js';
+import { loadDiscordConfig } from '../../models/discordConfig.js';
+import fetch from 'node-fetch';
+
+jest.mock('../../db.js', () => ({ pool: { query: jest.fn() } }));
+jest.mock('../../models/discordConfig.js', () => ({ loadDiscordConfig: jest.fn() }));
+jest.mock('node-fetch', () => jest.fn());
+
+describe('checkAndNotify', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('sends discord message when not recently notified', async () => {
+    pool.query
+      .mockResolvedValueOnce({ rows: [{ id: 1, name: 'P', qty: 2, last_added: null }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({});
+    loadDiscordConfig.mockResolvedValue({ token: 't', channelId: 'c' });
+    fetch.mockResolvedValue({ ok: true });
+
+    await checkAndNotify();
+
+    expect(fetch).toHaveBeenCalled();
+    expect(pool.query).toHaveBeenCalledWith(
+      'INSERT INTO notification_logs (product_id, sent_at) VALUES ($1, NOW())',
+      [1]
+    );
+  });
+});
+

--- a/backend/src/services/discordNotifier.js
+++ b/backend/src/services/discordNotifier.js
@@ -1,0 +1,61 @@
+import fetch from "node-fetch";
+import { pool } from "../db.js";
+import { loadDiscordConfig } from "../models/discordConfig.js";
+
+export async function searchAmazon(name) {
+  // Amazon API placeholder
+  return {
+    url: `https://www.amazon.co.jp/s?k=${encodeURIComponent(name)}`,
+  };
+}
+
+async function sendDiscord(message) {
+  const conf = await loadDiscordConfig();
+  if (!conf) return;
+  const url = `https://discord.com/api/channels/${conf.channelId}/messages`;
+  await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${conf.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ content: message }),
+  });
+}
+
+export async function checkAndNotify() {
+  const { rows: products } = await pool.query(`
+      SELECT p.id, p.name,
+             COALESCE(SUM(s.total_quantity),0) AS qty,
+             (SELECT MAX(created_at) FROM stock_history sh WHERE sh.product_id = p.id) AS last_added
+        FROM products p
+        LEFT JOIN stock s ON s.product_id = p.id
+       WHERE p.notify = true
+       GROUP BY p.id
+  `);
+
+  for (const p of products) {
+    const { rows: logs } = await pool.query(
+      "SELECT 1 FROM notification_logs WHERE product_id=$1 AND sent_at >= NOW() - INTERVAL '7 days'",
+      [p.id]
+    );
+    if (logs.length) continue;
+
+    const result = await searchAmazon(p.name);
+    const url = result?.url || "";
+    const date = p.last_added ? new Date(p.last_added).toISOString().split("T")[0] : "-";
+    const message = `商品: ${p.name}\n在庫数: ${p.qty}\n最終追加: ${date}\n${url}`;
+    await sendDiscord(message);
+    await pool.query(
+      "INSERT INTO notification_logs (product_id, sent_at) VALUES ($1, NOW())",
+      [p.id]
+    );
+  }
+}
+
+export function scheduleDailyNotifications() {
+  const day = 24 * 60 * 60 * 1000;
+  setInterval(checkAndNotify, day);
+  checkAndNotify();
+}
+

--- a/db/init/00_init.sql
+++ b/db/init/00_init.sql
@@ -21,6 +21,7 @@ CREATE TABLE IF NOT EXISTS products (
   brand      TEXT,
   group_key  TEXT,
   group_id   INT REFERENCES groups(id),   -- ← 紐づけ
+  notify     BOOLEAN NOT NULL DEFAULT false,
   meta_json  JSONB,
   created_at TIMESTAMPTZ DEFAULT now(),
   updated_at TIMESTAMPTZ DEFAULT now()
@@ -53,6 +54,18 @@ CREATE TABLE stock_history (
     shelf_id        INTEGER NOT NULL,
     add_quantity    INTEGER NOT NULL,
     created_at      TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE notification_logs (
+    id          SERIAL PRIMARY KEY,
+    product_id  INTEGER NOT NULL REFERENCES products(id),
+    sent_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE discord_config (
+    id SERIAL PRIMARY KEY,
+    encrypted_token   TEXT NOT NULL,
+    encrypted_channel TEXT NOT NULL
 );
 
 


### PR DESCRIPTION
## Why
Add notification feature with Amazon search and Discord integration.

## What
- add notify column and tables in init SQL
- support notify field in product model
- routes to toggle notifications and set Discord config
- Discord notifier service with daily scheduler
- Jest tests for new modules

## How tested
- `npm run lint --prefix backend` *(fails: missing @eslint/js)*
- `npm test --prefix backend` *(fails: jest not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68730fc359cc832e94a8d419d1a56411