### PR TITLE
feature(frontend): add discord settings and notify checkbox

### DIFF
--- a/backend/src/routes/discord.js
+++ b/backend/src/routes/discord.js
@@ -1,5 +1,6 @@
 import express from "express";
 import { saveDiscordConfig } from "../models/discordConfig.js";
+import { sendDiscordMessage } from "../services/discordNotifier.js";
 
 const router = express.Router();
 
@@ -10,6 +11,16 @@ router.post("/config", async (req, res, next) => {
       return res.status(400).json({ error: "invalid_config" });
     }
     await saveDiscordConfig(token, channelId);
+    res.status(204).end();
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post("/test", async (req, res, next) => {
+  try {
+    const { message } = req.body || {};
+    await sendDiscordMessage(message || "テスト送信");
     res.status(204).end();
   } catch (err) {
     next(err);

--- a/backend/src/services/__tests__/discordNotifier.test.js
+++ b/backend/src/services/__tests__/discordNotifier.test.js
@@ -8,7 +8,7 @@ jest.unstable_mockModule('../../models/discordConfig.js', () => ({
 jest.unstable_mockModule('node-fetch', () => ({ default: jest.fn() }));
 
 const { default: fetch } = await import('node-fetch');
-const { checkAndNotify } = await import('../discordNotifier.js');
+const { checkAndNotify, sendDiscordMessage } = await import('../discordNotifier.js');
 const { pool } = await import('../../db.js');
 const discordConfigModule = await import('../../models/discordConfig.js');
 
@@ -32,6 +32,19 @@ describe('checkAndNotify', () => {
       'INSERT INTO notification_logs (product_id, sent_at) VALUES ($1, NOW())',
       [1]
     );
+  });
+});
+
+describe('sendDiscordMessage', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  test('sends a discord message', async () => {
+    discordConfigModule.loadDiscordConfig.mockResolvedValue({ token: 't', channelId: 'c' });
+    fetch.mockResolvedValue({ ok: true });
+
+    await sendDiscordMessage('hello');
+
+    expect(fetch).toHaveBeenCalled();
   });
 });
 

--- a/backend/src/services/discordNotifier.js
+++ b/backend/src/services/discordNotifier.js
@@ -9,7 +9,7 @@ export async function searchAmazon(name) {
   };
 }
 
-async function sendDiscord(message) {
+export async function sendDiscordMessage(message) {
   const conf = await loadDiscordConfig();
   if (!conf) return;
   const url = `https://discord.com/api/channels/${conf.channelId}/messages`;
@@ -45,7 +45,7 @@ export async function checkAndNotify() {
     const url = result?.url || "";
     const date = p.last_added ? new Date(p.last_added).toISOString().split("T")[0] : "-";
     const message = `商品: ${p.name}\n在庫数: ${p.qty}\n最終追加: ${date}\n${url}`;
-    await sendDiscord(message);
+    await sendDiscordMessage(message);
     await pool.query(
       "INSERT INTO notification_logs (product_id, sent_at) VALUES ($1, NOW())",
       [p.id]

--- a/frontend/app/products/[id]/page.tsx
+++ b/frontend/app/products/[id]/page.tsx
@@ -2,7 +2,7 @@
 import { notFound, redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import Image from "next/image";
-import { apiGet, apiPut, apiDelete } from "@/lib/api";
+import { apiGet, apiPut, apiDelete, apiPatch } from "@/lib/api";
 import { Button, Input, Label } from "@/lib/form";
 import DeleteProductButton from "@/components/DeleteProductButton";
 import { uploadToS3 } from "@/lib/s3";
@@ -12,6 +12,7 @@ type Product = {
   name: string;
   brand: string | null;
   imageUrl: string | null;
+  notify: boolean;
 };
 
 async function getProduct(id: string) {
@@ -28,6 +29,7 @@ async function updateProductAction(formData: FormData) {
   const id = formData.get("id") as string;
   const name = formData.get("name") as string;
   const brand = formData.get("brand") as string;
+  const notify = formData.get("notify") === "on";
   const imageFile = formData.get("image") as File;
 
   let imageUrl: string | undefined = undefined;
@@ -51,6 +53,7 @@ async function updateProductAction(formData: FormData) {
       payload.imageUrl = imageUrl;
     }
     await apiPut(`/api/products/${id}`, payload);
+    await apiPatch(`/api/products/${id}/notify`, { notify });
   } catch (err) {
     console.error("Failed to update product:", err);
     // TODO: エラーメッセージをユーザーに表示する
@@ -134,6 +137,16 @@ export default async function ProductEditPage({
           <Label htmlFor="brand">ブランド</Label>
           <Input name="brand" id="brand" defaultValue={product.brand ?? ""} />
         </div>
+
+        <label className="inline-flex items-center gap-2">
+          <input
+            type="checkbox"
+            name="notify"
+            defaultChecked={product.notify}
+            className="accent-blue-600"
+          />
+          <span>通知</span>
+        </label>
 
         <Button>更新</Button>
       </form>

--- a/frontend/app/settings/discord/page.tsx
+++ b/frontend/app/settings/discord/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from "next/navigation";
+import { apiPost, apiGet } from "@/lib/api";
+import { Button, Input, Label } from "@/lib/form";
+
+export const dynamic = "force-dynamic";
+
+type Product = { id: number; name: string; notify: boolean };
+
+async function saveDiscordConfig(formData: FormData) {
+  "use server";
+  const token = formData.get("token") as string;
+  const channelId = formData.get("channelId") as string;
+
+  try {
+    await apiPost("/api/discord/config", { token, channelId });
+  } catch (err) {
+    console.error("Failed to save discord config:", err);
+    return;
+  }
+
+  redirect("/settings/discord?success=1");
+}
+
+export default async function DiscordSettingsPage({
+  searchParams,
+}: {
+  searchParams?: { success?: string };
+}) {
+  const products = await apiGet<Product[]>("/api/products");
+  const notifyProducts = products.filter((p) => p.notify);
+
+  return (
+    <div className="p-4 max-w-md mx-auto space-y-6">
+      <h1 className="text-xl font-semibold">Discord設定</h1>
+      {searchParams?.success && <p className="text-green-600">保存しました</p>}
+      <form action={saveDiscordConfig} className="space-y-4">
+        <div>
+          <Label htmlFor="token">Bot Token</Label>
+          <Input id="token" name="token" type="password" required />
+        </div>
+        <div>
+          <Label htmlFor="channelId">Channel ID</Label>
+          <Input id="channelId" name="channelId" required />
+        </div>
+        <Button>保存</Button>
+      </form>
+
+      <div>
+        <h2 className="text-lg font-semibold">通知対象商品</h2>
+        {notifyProducts.length === 0 ? (
+          <p className="text-gray-500">通知対象の商品はありません。</p>
+        ) : (
+          <ul className="list-disc pl-5 space-y-1">
+            {notifyProducts.map((p) => (
+              <li key={p.id}>
+                <a
+                  href={`https://www.amazon.co.jp/s?k=${encodeURIComponent(p.name)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {p.name}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/settings/discord/page.tsx
+++ b/frontend/app/settings/discord/page.tsx
@@ -21,10 +21,20 @@ async function saveDiscordConfig(formData: FormData) {
   redirect("/settings/discord?success=1");
 }
 
+async function sendTest() {
+  "use server";
+  try {
+    await apiPost("/api/discord/test", {});
+    redirect("/settings/discord?tested=1");
+  } catch (err) {
+    console.error("Failed to send test message:", err);
+  }
+}
+
 export default async function DiscordSettingsPage({
   searchParams,
 }: {
-  searchParams?: { success?: string };
+  searchParams?: { success?: string; tested?: string };
 }) {
   const products = await apiGet<Product[]>("/api/products");
   const notifyProducts = products.filter((p) => p.notify);
@@ -33,6 +43,7 @@ export default async function DiscordSettingsPage({
     <div className="p-4 max-w-md mx-auto space-y-6">
       <h1 className="text-xl font-semibold">Discord設定</h1>
       {searchParams?.success && <p className="text-green-600">保存しました</p>}
+      {searchParams?.tested && <p className="text-green-600">送信しました</p>}
       <form action={saveDiscordConfig} className="space-y-4">
         <div>
           <Label htmlFor="token">Bot Token</Label>
@@ -43,6 +54,10 @@ export default async function DiscordSettingsPage({
           <Input id="channelId" name="channelId" required />
         </div>
         <Button>保存</Button>
+      </form>
+
+      <form action={sendTest}>
+        <Button type="submit">テスト送信</Button>
       </form>
 
       <div>

--- a/frontend/app/settings/discord/page.tsx
+++ b/frontend/app/settings/discord/page.tsx
@@ -25,10 +25,12 @@ async function sendTest() {
   "use server";
   try {
     await apiPost("/api/discord/test", {});
-    redirect("/settings/discord?tested=1");
   } catch (err) {
     console.error("Failed to send test message:", err);
+    return;
   }
+
+  redirect("/settings/discord?tested=1");
 }
 
 export default async function DiscordSettingsPage({

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -37,7 +37,7 @@ export class ApiError extends Error {
 
 export async function apiDelete(
   path: string,
-  init: RequestInit = {}
+  init: RequestInit = {},
 ): Promise<void> {
   const url = path.startsWith("http") ? path : `${getApiBase()}${path}`;
   const headers: HeadersInit = { ...init.headers };
@@ -66,7 +66,7 @@ export async function apiDelete(
 /** GET helper (JSON) */
 export async function apiGet<T = unknown>(
   path: string,
-  init: RequestInit = {}
+  init: RequestInit = {},
 ): Promise<T> {
   const url = path.startsWith("http") ? path : `${getApiBase()}${path}`;
   const headers: HeadersInit = { ...init.headers };
@@ -89,7 +89,7 @@ export async function apiGet<T = unknown>(
 export async function apiPut<T = unknown>(
   path: string,
   body: unknown,
-  init: RequestInit = {}
+  init: RequestInit = {},
 ): Promise<T> {
   const url = path.startsWith("http") ? path : `${getApiBase()}${path}`;
   const headers: HeadersInit = {
@@ -120,7 +120,7 @@ export async function apiPut<T = unknown>(
 export async function apiPost<T = unknown>(
   path: string,
   body: unknown,
-  init: RequestInit = {}
+  init: RequestInit = {},
 ): Promise<T> {
   const url = path.startsWith("http") ? path : `${getApiBase()}${path}`;
   const headers: HeadersInit = {
@@ -139,6 +139,36 @@ export async function apiPost<T = unknown>(
 
   const res = await fetch(url, {
     method: "POST",
+    body: JSON.stringify(body),
+    ...init,
+    headers,
+  });
+  if (!res.ok) throw new ApiError(res.status);
+  return res.json() as Promise<T>;
+}
+
+/** PATCH helper (JSON) */
+export async function apiPatch<T = unknown>(
+  path: string,
+  body: unknown,
+  init: RequestInit = {},
+): Promise<T> {
+  const url = path.startsWith("http") ? path : `${getApiBase()}${path}`;
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+    ...init.headers,
+  };
+
+  if (typeof window === "undefined") {
+    const { cookies } = await import("next/headers");
+    const cookieHeader = cookies().toString();
+    if (cookieHeader) {
+      headers["Cookie"] = cookieHeader;
+    }
+  }
+
+  const res = await fetch(url, {
+    method: "PATCH",
     body: JSON.stringify(body),
     ...init,
     headers,

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -113,6 +113,7 @@ export async function apiPut<T = unknown>(
     headers,
   });
   if (!res.ok) throw new ApiError(res.status);
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
 
@@ -144,6 +145,7 @@ export async function apiPost<T = unknown>(
     headers,
   });
   if (!res.ok) throw new ApiError(res.status);
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }
 
@@ -174,5 +176,6 @@ export async function apiPatch<T = unknown>(
     headers,
   });
   if (!res.ok) throw new ApiError(res.status);
+  if (res.status === 204) return undefined as T;
   return res.json() as Promise<T>;
 }


### PR DESCRIPTION
## Why
Add ability to configure Discord and enable per-product notifications.

## What
- added `apiPatch` helper and updated product forms with "通知" checkbox
- new Discord settings page for token/channel and list of notified products

## How tested
- `npm --prefix frontend run lint`
- `npm --prefix frontend run typecheck`
- `npm --prefix backend test`


------
https://chatgpt.com/codex/tasks/task_e_687364a79918832e96c3d93dd9529616